### PR TITLE
MUL-648 GSN RelayClient fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.5",
+  "version": "0.4.5-MUL-648",
   "description": "Tabookey Gasless Relay Framework",
   "name": "tabookey-gasless",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.5-MUL-648",
+  "version": "0.4.5-multis-001",
   "description": "Tabookey Gasless Relay Framework",
   "name": "tabookey-gasless",
   "license": "MIT",

--- a/src/js/relayclient/ServerHelper.js
+++ b/src/js/relayclient/ServerHelper.js
@@ -245,12 +245,15 @@ class ServerHelper {
             throw new Error("no valid relays. orig relays=" + JSON.stringify(origRelays))
         }
 
+        filteredRelays = filteredRelays.slice(0, this.maxRelayToPing);
+
         if (this.verbose){
             console.log("fetchRelaysAdded: after filtering have " + filteredRelays.length + " active relays")
         }
-
-        this.filteredRelays = filteredRelays.slice(0, this.maxRelayToPing);
+        
+        this.filteredRelays = filteredRelays;
         this.isInitialized = true;
+
         return filteredRelays;
     }
 }

--- a/src/js/relayclient/ServerHelper.js
+++ b/src/js/relayclient/ServerHelper.js
@@ -188,11 +188,12 @@ class ServerHelper {
         if (typeof this.relayHubInstance === 'undefined') {
             throw new Error("Must call to setHub first!")
         }
-        if (this.filteredRelays.length == 0 || this.fromBlock !== fromBlock)
-        {
+        // Always fetch relays (issue when user click, reject signature and reclick)
+        //if (this.filteredRelays.length == 0 || this.fromBlock !== fromBlock)
+        //{
             this.fromBlock = fromBlock
             await this.fetchRelaysAdded()
-        }
+        //}
         return this.createActiveRelayPinger(this.filteredRelays, this.httpSend, gasPrice, this.verbose)
     }
 

--- a/src/js/relayclient/ServerHelper.js
+++ b/src/js/relayclient/ServerHelper.js
@@ -122,6 +122,7 @@ class ServerHelper {
                 relayFilter,        //function: return false to filter out a relay. default uses minStake, minDelay
                 addScoreRandomness,  //function: return Math.random (0..1), to fairly distribute among relays with same score.
                                      // (used by test to REMOVE the randomness, and make the test deterministic.
+                maxRelayToPing       // Number max of relay to ping (default 3)
             }) {
 
         this.httpSend = httpSend
@@ -132,6 +133,8 @@ class ServerHelper {
         this.addScoreRandomness = addScoreRandomness || Math.random
 
         this.calculateRelayScore = calculateRelayScore || this.defaultCalculateRelayScore.bind(this)
+
+        this.maxRelayToPing = maxRelayToPing || 3
 
         //default filter: either calculateRelayScore didn't set "score" field,
         // or if unstakeDelay is below min, or if stake is below min.
@@ -246,7 +249,7 @@ class ServerHelper {
             console.log("fetchRelaysAdded: after filtering have " + filteredRelays.length + " active relays")
         }
 
-        this.filteredRelays = filteredRelays;
+        this.filteredRelays = filteredRelays.slice(0, this.maxRelayToPing);
         this.isInitialized = true;
         return filteredRelays;
     }

--- a/src/js/relayclient/ServerHelper.js
+++ b/src/js/relayclient/ServerHelper.js
@@ -239,13 +239,13 @@ class ServerHelper {
         }
 
         const origRelays = Object.values(activeRelays)
-        const filteredRelays = origRelays.filter(this.relayFilter).sort(this.compareRelayScores.bind(this));
+        const filteredRelays = origRelays.filter(this.relayFilter)
+                                         .sort(this.compareRelayScores.bind(this))
+                                         .slice(0, this.maxRelayToPing);
 
         if (filteredRelays.length == 0) {
             throw new Error("no valid relays. orig relays=" + JSON.stringify(origRelays))
         }
-
-        filteredRelays = filteredRelays.slice(0, this.maxRelayToPing);
 
         if (this.verbose){
             console.log("fetchRelaysAdded: after filtering have " + filteredRelays.length + " active relays")

--- a/src/js/relayclient/utils.js
+++ b/src/js/relayclient/utils.js
@@ -66,17 +66,19 @@ module.exports = {
             })
 
         } catch (e) {
-            if(!e.message.includes("User denied message signature")) {
-                sig_ = await new Promise((resolve, reject) => {
+            
+            sig_ = await new Promise((resolve, reject) => {
+                console.log(e)
+                console.log()
+                if(!e.message.includes("User denied message signature")) {
                     web3.eth.sign(hash, account, (err, res) => {
                         if (err) reject(err)
                         else resolve(res)
                     })
-                })
-            } else {
-                reject(e)
-            }
-            
+                } else {
+                    reject(e)
+                }
+            })
         }
 
         let signature = ethUtils.fromRpcSig(sig_);

--- a/src/js/relayclient/utils.js
+++ b/src/js/relayclient/utils.js
@@ -54,8 +54,7 @@ module.exports = {
 
         let sig_
         try {
-
-
+            console.log("web3.eth.personal -- hash="+hash)
             sig_ = await new Promise((resolve, reject) => {
                 try {
                     web3.eth.personal.sign(hash, account, (err, res) => {
@@ -69,6 +68,8 @@ module.exports = {
 
         } catch (e) {
 
+            console.log("web3.eth.sign -- hash="+hash)
+            console.log(e)
             sig_ = await new Promise((resolve, reject) => {
                 web3.eth.sign(hash, account, (err, res) => {
                     if (err) reject(err)

--- a/src/js/relayclient/utils.js
+++ b/src/js/relayclient/utils.js
@@ -54,7 +54,6 @@ module.exports = {
 
         let sig_
         try {
-            console.log("web3.eth.personal -- hash="+hash)
             sig_ = await new Promise((resolve, reject) => {
                 try {
                     web3.eth.personal.sign(hash, account, (err, res) => {
@@ -67,15 +66,17 @@ module.exports = {
             })
 
         } catch (e) {
-
-            console.log("web3.eth.sign -- hash="+hash)
-            console.log(e)
-            sig_ = await new Promise((resolve, reject) => {
-                web3.eth.sign(hash, account, (err, res) => {
-                    if (err) reject(err)
-                    else resolve(res)
+            if(!e.includes("User denied message signature")) {
+                sig_ = await new Promise((resolve, reject) => {
+                    web3.eth.sign(hash, account, (err, res) => {
+                        if (err) reject(err)
+                        else resolve(res)
+                    })
                 })
-            })
+            } else {
+                reject(e)
+            }
+            
         }
 
         let signature = ethUtils.fromRpcSig(sig_);

--- a/src/js/relayclient/utils.js
+++ b/src/js/relayclient/utils.js
@@ -66,7 +66,7 @@ module.exports = {
             })
 
         } catch (e) {
-            if(!e.includes("User denied message signature")) {
+            if(!e.message.includes("User denied message signature")) {
                 sig_ = await new Promise((resolve, reject) => {
                     web3.eth.sign(hash, account, (err, res) => {
                         if (err) reject(err)

--- a/src/js/relayclient/utils.js
+++ b/src/js/relayclient/utils.js
@@ -66,10 +66,7 @@ module.exports = {
             })
 
         } catch (e) {
-            
             sig_ = await new Promise((resolve, reject) => {
-                console.log(e)
-                console.log()
                 if(!e.message.includes("User denied message signature")) {
                     web3.eth.sign(hash, account, (err, res) => {
                         if (err) reject(err)


### PR DESCRIPTION



- **Fix double signature (on deny)**
it was happening because `web3.eth.sign(msg)` was called in the catch of `web3.eth.personal.sign(msg)`.
I now fallback on `web3.eth.sign(msg)` only if the error message is different than `User denied message signature`


- **Limit the number of relay**
Use the option `maxRelayToPing` (default 3) to limit the number of relay in the pool of active relayers. So we can avoid multi signature popup when something goes wrong (balance too low for instance)

- **Fix error empty relayer pool.**
The relayer pool is refreshed for each call (instead of block based), this was causing an issue when a user cancel a signature (relayers removed from the pool) and try again (no more relayer in the pool). Now it's refetched all the time

