### PR TITLE
MUL-648 GSN RelayClient fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.5",
+  "version": "0.4.5-MUL-648",
   "description": "Tabookey Gasless Relay Framework",
   "name": "tabookey-gasless",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.5-MUL-648",
+  "version": "0.4.5-multis-001",
   "description": "Tabookey Gasless Relay Framework",
   "name": "tabookey-gasless",
   "license": "MIT",

--- a/src/js/relayclient/ServerHelper.js
+++ b/src/js/relayclient/ServerHelper.js
@@ -191,12 +191,12 @@ class ServerHelper {
         if (typeof this.relayHubInstance === 'undefined') {
             throw new Error("Must call to setHub first!")
         }
-        // Always fetch relays (issue when user click, reject signature and reclick)
-        //if (this.filteredRelays.length == 0 || this.fromBlock !== fromBlock)
-        //{
+
+        if (this.filteredRelays.length == 0 || this.fromBlock !== fromBlock)
+        {
             this.fromBlock = fromBlock
             await this.fetchRelaysAdded()
-        //}
+        }
         return this.createActiveRelayPinger(this.filteredRelays, this.httpSend, gasPrice, this.verbose)
     }
 
@@ -212,16 +212,11 @@ class ServerHelper {
         let activeRelays = {}
         let fromBlock = this.fromBlock || 2;
 
-        let addedAndRemovedEvents = []
-        let i = 0
-        do {
-            addedAndRemovedEvents = await this.relayHubInstance.getPastEvents("allEvents", { 
+        let addedAndRemovedEvents = await this.relayHubInstance.getPastEvents("allEvents", { 
                 fromBlock: fromBlock,
                 topics: [["0x85b3ae3aae9d3fcb31142fbd8c3b4722d57825b8edd6e1366e69204afa5a0dfa", // RelayAdded
                           "0x5490afc1d818789c8b3d5d63bce3d2a3327d0bba4efb5a7751f783dc977d7d11" // RelayRemoved
-                        ]]})
-            i++
-          } while (i < 10 && addedAndRemovedEvents.length > 0 && addedAndRemovedEvents[0].event === undefined);
+                        ]]});
 
         if (this.verbose){
             console.log("fetchRelaysAdded: found " + addedAndRemovedEvents.length + " events")

--- a/src/js/relayclient/ServerHelper.js
+++ b/src/js/relayclient/ServerHelper.js
@@ -181,7 +181,8 @@ class ServerHelper {
      * @param {*} relayHubInstance
      */
     setHub(relayHubInstance) {
-        if (this.relayHubInstance._address !== relayHubInstance._address){
+        console.log(this.relayHubInstance)
+        if (this.relayHubInstance && this.relayHubInstance._address !== relayHubInstance._address){
             this.filteredRelays = []
         }
         this.relayHubInstance = relayHubInstance

--- a/src/js/relayclient/ServerHelper.js
+++ b/src/js/relayclient/ServerHelper.js
@@ -212,7 +212,7 @@ class ServerHelper {
         let activeRelays = {}
         let fromBlock = this.fromBlock || 2;
         let addedAndRemovedEvents = await this.relayHubInstance.getPastEvents("allEvents", { fromBlock: fromBlock,
-            // topics: [["RelayAdded", "RelayRemoved"]]
+            topics: [["RelayAdded", "RelayRemoved"]]
         })
 
         if (this.verbose){

--- a/src/js/relayclient/ServerHelper.js
+++ b/src/js/relayclient/ServerHelper.js
@@ -8,7 +8,7 @@ class ActiveRelayPinger {
 
     // TODO: 'httpSend' should be on a network layer
     constructor(filteredRelays, httpSend, gasPrice, verbose) {
-        this.remainingRelays = filteredRelays.slice()
+        this.remainingRelays = [...filteredRelays]
         this.httpSend = httpSend
         this.pingedRelays = 0
         this.relaysCount = filteredRelays.length
@@ -192,8 +192,7 @@ class ServerHelper {
             throw new Error("Must call to setHub first!")
         }
 
-        if (this.filteredRelays.length == 0 || this.fromBlock !== fromBlock)
-        {
+        if (this.filteredRelays.length == 0 || this.fromBlock !== fromBlock) {
             this.fromBlock = fromBlock
             await this.fetchRelaysAdded()
         }

--- a/src/js/relayclient/ServerHelper.js
+++ b/src/js/relayclient/ServerHelper.js
@@ -211,11 +211,17 @@ class ServerHelper {
     async fetchRelaysAdded() {
         let activeRelays = {}
         let fromBlock = this.fromBlock || 2;
-        let addedAndRemovedEvents = await this.relayHubInstance.getPastEvents("allEvents", { fromBlock: fromBlock,
-            topics: [["0x85b3ae3aae9d3fcb31142fbd8c3b4722d57825b8edd6e1366e69204afa5a0dfa", // RelayAdded
-                      "0x5490afc1d818789c8b3d5d63bce3d2a3327d0bba4efb5a7751f783dc977d7d11" // RelayRemoved
-                    ]] 
-        })
+
+        let addedAndRemovedEvents = []
+        let i = 0
+        do {
+            addedAndRemovedEvents = await this.relayHubInstance.getPastEvents("allEvents", { 
+                fromBlock: fromBlock,
+                topics: [["0x85b3ae3aae9d3fcb31142fbd8c3b4722d57825b8edd6e1366e69204afa5a0dfa", // RelayAdded
+                          "0x5490afc1d818789c8b3d5d63bce3d2a3327d0bba4efb5a7751f783dc977d7d11" // RelayRemoved
+                        ]]})
+            i++
+          } while (i < 10 && addedAndRemovedEvents.length > 0 && addedAndRemovedEvents[0].event === undefined);
 
         if (this.verbose){
             console.log("fetchRelaysAdded: found " + addedAndRemovedEvents.length + " events")

--- a/src/js/relayclient/ServerHelper.js
+++ b/src/js/relayclient/ServerHelper.js
@@ -245,12 +245,15 @@ class ServerHelper {
             throw new Error("no valid relays. orig relays=" + JSON.stringify(origRelays))
         }
 
+        filteredRelays = filteredRelays.slice(0, this.maxRelayToPing);
+
         if (this.verbose){
             console.log("fetchRelaysAdded: after filtering have " + filteredRelays.length + " active relays")
         }
-
-        this.filteredRelays = filteredRelays.slice(0, this.maxRelayToPing);
+        
+        this.filteredRelays = filteredRelays;
         this.isInitialized = true;
+
         return filteredRelays;
     }
 }

--- a/src/js/relayclient/ServerHelper.js
+++ b/src/js/relayclient/ServerHelper.js
@@ -188,11 +188,12 @@ class ServerHelper {
         if (typeof this.relayHubInstance === 'undefined') {
             throw new Error("Must call to setHub first!")
         }
-        if (this.filteredRelays.length == 0 || this.fromBlock !== fromBlock)
-        {
+        // Always fetch relays (issue when user click, reject signature and reclick)
+        //if (this.filteredRelays.length == 0 || this.fromBlock !== fromBlock)
+        //{
             this.fromBlock = fromBlock
             await this.fetchRelaysAdded()
-        }
+        //}
         return this.createActiveRelayPinger(this.filteredRelays, this.httpSend, gasPrice, this.verbose)
     }
 

--- a/src/js/relayclient/ServerHelper.js
+++ b/src/js/relayclient/ServerHelper.js
@@ -181,7 +181,6 @@ class ServerHelper {
      * @param {*} relayHubInstance
      */
     setHub(relayHubInstance) {
-        console.log(this.relayHubInstance)
         if (this.relayHubInstance && this.relayHubInstance._address !== relayHubInstance._address){
             this.filteredRelays = []
         }

--- a/src/js/relayclient/ServerHelper.js
+++ b/src/js/relayclient/ServerHelper.js
@@ -212,7 +212,9 @@ class ServerHelper {
         let activeRelays = {}
         let fromBlock = this.fromBlock || 2;
         let addedAndRemovedEvents = await this.relayHubInstance.getPastEvents("allEvents", { fromBlock: fromBlock,
-            topics: [["RelayAdded", "RelayRemoved"]]
+            topics: [["0x85b3ae3aae9d3fcb31142fbd8c3b4722d57825b8edd6e1366e69204afa5a0dfa", // RelayAdded
+                      "0x5490afc1d818789c8b3d5d63bce3d2a3327d0bba4efb5a7751f783dc977d7d11" // RelayRemoved
+                    ]] 
         })
 
         if (this.verbose){

--- a/src/js/relayclient/ServerHelper.js
+++ b/src/js/relayclient/ServerHelper.js
@@ -8,7 +8,7 @@ class ActiveRelayPinger {
 
     // TODO: 'httpSend' should be on a network layer
     constructor(filteredRelays, httpSend, gasPrice, verbose) {
-        this.remainingRelays = [...filteredRelays]
+        this.remainingRelays = filteredRelays.slice()
         this.httpSend = httpSend
         this.pingedRelays = 0
         this.relaysCount = filteredRelays.length
@@ -181,7 +181,7 @@ class ServerHelper {
      * @param {*} relayHubInstance
      */
     setHub(relayHubInstance) {
-        if (this.relayHubInstance !== relayHubInstance){
+        if (this.relayHubInstance._address !== relayHubInstance._address){
             this.filteredRelays = []
         }
         this.relayHubInstance = relayHubInstance

--- a/src/js/relayclient/ServerHelper.js
+++ b/src/js/relayclient/ServerHelper.js
@@ -122,6 +122,7 @@ class ServerHelper {
                 relayFilter,        //function: return false to filter out a relay. default uses minStake, minDelay
                 addScoreRandomness,  //function: return Math.random (0..1), to fairly distribute among relays with same score.
                                      // (used by test to REMOVE the randomness, and make the test deterministic.
+                maxRelayToPing       // Number max of relay to ping (default 3)
             }) {
 
         this.httpSend = httpSend
@@ -132,6 +133,8 @@ class ServerHelper {
         this.addScoreRandomness = addScoreRandomness || Math.random
 
         this.calculateRelayScore = calculateRelayScore || this.defaultCalculateRelayScore.bind(this)
+
+        this.maxRelayToPing = maxRelayToPing || 3
 
         //default filter: either calculateRelayScore didn't set "score" field,
         // or if unstakeDelay is below min, or if stake is below min.
@@ -246,7 +249,7 @@ class ServerHelper {
             console.log("fetchRelaysAdded: after filtering have " + filteredRelays.length + " active relays")
         }
 
-        this.filteredRelays = filteredRelays;
+        this.filteredRelays = filteredRelays.slice(0, this.maxRelayToPing);
         this.isInitialized = true;
         return filteredRelays;
     }

--- a/src/js/relayclient/ServerHelper.js
+++ b/src/js/relayclient/ServerHelper.js
@@ -239,13 +239,13 @@ class ServerHelper {
         }
 
         const origRelays = Object.values(activeRelays)
-        const filteredRelays = origRelays.filter(this.relayFilter).sort(this.compareRelayScores.bind(this));
+        const filteredRelays = origRelays.filter(this.relayFilter)
+                                         .sort(this.compareRelayScores.bind(this))
+                                         .slice(0, this.maxRelayToPing);
 
         if (filteredRelays.length == 0) {
             throw new Error("no valid relays. orig relays=" + JSON.stringify(origRelays))
         }
-
-        filteredRelays = filteredRelays.slice(0, this.maxRelayToPing);
 
         if (this.verbose){
             console.log("fetchRelaysAdded: after filtering have " + filteredRelays.length + " active relays")

--- a/src/js/relayclient/utils.js
+++ b/src/js/relayclient/utils.js
@@ -66,17 +66,19 @@ module.exports = {
             })
 
         } catch (e) {
-            if(!e.message.includes("User denied message signature")) {
-                sig_ = await new Promise((resolve, reject) => {
+            
+            sig_ = await new Promise((resolve, reject) => {
+                console.log(e)
+                console.log()
+                if(!e.message.includes("User denied message signature")) {
                     web3.eth.sign(hash, account, (err, res) => {
                         if (err) reject(err)
                         else resolve(res)
                     })
-                })
-            } else {
-                reject(e)
-            }
-            
+                } else {
+                    reject(e)
+                }
+            })
         }
 
         let signature = ethUtils.fromRpcSig(sig_);

--- a/src/js/relayclient/utils.js
+++ b/src/js/relayclient/utils.js
@@ -54,8 +54,7 @@ module.exports = {
 
         let sig_
         try {
-
-
+            console.log("web3.eth.personal -- hash="+hash)
             sig_ = await new Promise((resolve, reject) => {
                 try {
                     web3.eth.personal.sign(hash, account, (err, res) => {
@@ -69,6 +68,8 @@ module.exports = {
 
         } catch (e) {
 
+            console.log("web3.eth.sign -- hash="+hash)
+            console.log(e)
             sig_ = await new Promise((resolve, reject) => {
                 web3.eth.sign(hash, account, (err, res) => {
                     if (err) reject(err)

--- a/src/js/relayclient/utils.js
+++ b/src/js/relayclient/utils.js
@@ -54,7 +54,6 @@ module.exports = {
 
         let sig_
         try {
-            console.log("web3.eth.personal -- hash="+hash)
             sig_ = await new Promise((resolve, reject) => {
                 try {
                     web3.eth.personal.sign(hash, account, (err, res) => {
@@ -67,15 +66,17 @@ module.exports = {
             })
 
         } catch (e) {
-
-            console.log("web3.eth.sign -- hash="+hash)
-            console.log(e)
-            sig_ = await new Promise((resolve, reject) => {
-                web3.eth.sign(hash, account, (err, res) => {
-                    if (err) reject(err)
-                    else resolve(res)
+            if(!e.includes("User denied message signature")) {
+                sig_ = await new Promise((resolve, reject) => {
+                    web3.eth.sign(hash, account, (err, res) => {
+                        if (err) reject(err)
+                        else resolve(res)
+                    })
                 })
-            })
+            } else {
+                reject(e)
+            }
+            
         }
 
         let signature = ethUtils.fromRpcSig(sig_);

--- a/src/js/relayclient/utils.js
+++ b/src/js/relayclient/utils.js
@@ -66,7 +66,7 @@ module.exports = {
             })
 
         } catch (e) {
-            if(!e.includes("User denied message signature")) {
+            if(!e.message.includes("User denied message signature")) {
                 sig_ = await new Promise((resolve, reject) => {
                     web3.eth.sign(hash, account, (err, res) => {
                         if (err) reject(err)

--- a/src/js/relayclient/utils.js
+++ b/src/js/relayclient/utils.js
@@ -66,10 +66,7 @@ module.exports = {
             })
 
         } catch (e) {
-            
             sig_ = await new Promise((resolve, reject) => {
-                console.log(e)
-                console.log()
                 if(!e.message.includes("User denied message signature")) {
                     web3.eth.sign(hash, account, (err, res) => {
                         if (err) reject(err)


### PR DESCRIPTION

- **Fix double signature (on deny)**
it was happening because `web3.eth.sign(msg)` was called in the catch of `web3.eth.personal.sign(msg)`.
I now fallback on `web3.eth.sign(msg)` only if the error message is different than `User denied message signature`


- **Limit the number of relay**
Use the option `maxRelayToPing` (default 3) to limit the number of relay in the pool of active relayers. So we can avoid multi signature popup when something goes wrong (balance too low for instance)

- **Fix error empty relayer pool.**
Each relayTxn call is supposed to reused the active relay pool `filteredRelays` but the function setHub was incorrectly resetting to `[]` the pool because of a wrong condition `if (this.relayHubInstance!== relayHubInstance)` (never equal) instead of `if (this.relayHubInstance._address !== relayHubInstance._address)`


